### PR TITLE
fix: remove extra closing brace in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,6 @@ pipeline {
             }
         }
     }
-    }
     post {
         always {
             sh 'docker logout'


### PR DESCRIPTION
Fixes syntax error causing pipeline to fail with \"unexpected token: }\"