### PR TITLE
feat: add production-ready Helm charts with IRSA support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,7 +143,17 @@ business-case-docs/
 # The uploaded csv files
 src/uploads/
 helm/csv-processor/values-override.yaml
+
+# Terraform
 .terraform/
 .terraform.lock.hcl
-terraform.tfstate*
+terraform.tfstate
+terraform.tfstate.backup
+tfplan
 *.tfplan
+*.tfvars
+!terraform.tfvars.example
+
+# Helm
+charts/
+*.tgz

--- a/helm/csv-processor/templates/deployment.yaml
+++ b/helm/csv-processor/templates/deployment.yaml
@@ -18,10 +18,21 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "csv-processor.fullname" .) }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -39,6 +50,8 @@ spec:
                 configMapKeyRef:
                   name: {{ .Values.configmap.name | default "app-config" }}
                   key: S3_BUCKET_NAME
+            {{- if not .Values.serviceAccount.create }}
+            # Fallback to secrets if IRSA is not used
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -49,6 +62,15 @@ spec:
                 secretKeyRef:
                   name: {{ include "csv-processor.fullname" . }}-aws-credentials
                   key: AWS_SECRET_ACCESS_KEY
+            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/helm/csv-processor/templates/ingress.yaml
+++ b/helm/csv-processor/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "csv-processor.fullname" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "csv-processor.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+  - host: {{ .host | quote }}
+    http:
+      paths:
+      {{- range .paths }}
+      - path: {{ .path }}
+        pathType: {{ .pathType }}
+        backend:
+          service:
+            name: {{ include "csv-processor.fullname" $ }}-nginx
+            port:
+              number: {{ $.Values.service.nginx_port | default 80 }}
+      {{- end }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/csv-processor/templates/serviceaccount.yaml
+++ b/helm/csv-processor/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default (include "csv-processor.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "csv-processor.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken | default true }}
+{{- end }}

--- a/helm/csv-processor/values-production.yaml
+++ b/helm/csv-processor/values-production.yaml
@@ -1,0 +1,188 @@
+# Production values for csv-processor
+# Override values for production EKS deployment with IRSA
+
+replicaCount: 2  # Start with 2 replicas for HA
+
+image:
+  repository: oguzhanbolukbas/cloud-native-csv-processor
+  tag: latest
+  pullPolicy: Always  # Use Always for latest tag in production
+
+# Service Account for IRSA
+serviceAccount:
+  create: false  # Will be created by deployment script with proper annotations
+  name: csv-processor-sa
+
+service:
+  type: ClusterIP
+  port: 3000
+  nginx_port: 80
+
+resources:
+  limits:
+    cpu: 500m      # Increased for production workload
+    memory: 512Mi
+  requests:
+    cpu: 250m      # Higher baseline for production
+    memory: 256Mi
+
+# Production environment
+env:
+  NODE_ENV: production
+
+# Remove secrets section - using IRSA instead
+# AWS credentials will be provided via IAM roles
+
+configmap:
+  name: app-config
+  tier: backend
+  AWS_REGION: eu-north-1
+  S3_BUCKET_NAME: cloud-native-csv-processor-uploads-business-case
+  DOCKER_IMAGE_NAME: oguzhanbolukbas/cloud-native-csv-processor
+  DOCKER_IMAGE_TAG: latest
+
+# Nginx deployment values - production optimized
+nginx:
+  replicaCount: 2  # HA setup
+  image:
+    repository: nginx
+    tag: "1.25-alpine"  # Use specific version for production
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  
+  # Production HPA settings
+  hpa:
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    scaleDown:
+      stabilizationWindowSeconds: 300  # 5 minutes for production stability
+      percentPolicy:
+        value: 25  # Conservative scale-down
+        periodSeconds: 60
+      podsPolicy:
+        value: 1
+        periodSeconds: 60
+      selectPolicy: "Min"  # Conservative approach
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      percentPolicy:
+        value: 50
+        periodSeconds: 30
+      podsPolicy:
+        value: 2
+        periodSeconds: 30
+      selectPolicy: "Max"
+
+# API HPA values - production optimized
+hpa:
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  scaleDown:
+    stabilizationWindowSeconds: 300
+    percentPolicy:
+      value: 25
+      periodSeconds: 60
+    podsPolicy:
+      value: 1
+      periodSeconds: 60
+    selectPolicy: "Min"
+  scaleUp:
+    stabilizationWindowSeconds: 60
+    percentPolicy:
+      value: 50
+      periodSeconds: 30
+    podsPolicy:
+      value: 2
+      periodSeconds: 30
+    selectPolicy: "Max"
+
+# Storage configuration
+storageClass:
+  name: gp2  # Use gp2 for EKS
+
+pvc:
+  name: shared-static-pvc
+  accessMode: ReadWriteOnce
+  size: 5Gi  # Increased for production
+
+# Node selection and tolerations
+nodeSelector:
+  role: worker
+
+tolerations: []
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - csv-processor
+        topologyKey: kubernetes.io/hostname
+
+# Ingress configuration for AWS ALB
+ingress:
+  enabled: true
+  ingressClassName: alb
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+    alb.ingress.kubernetes.io/tags: Environment=production,Project=csv-processor
+    alb.ingress.kubernetes.io/healthcheck-path: /
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
+    alb.ingress.kubernetes.io/healthy-threshold-count: "2"
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+  hosts:
+    - host: ""  # No specific host, will accept all
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# Security context
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false  # App needs to write to uploads directory
+  capabilities:
+    drop:
+    - ALL
+
+# Probes for production
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3

--- a/helm/csv-processor/values.yaml
+++ b/helm/csv-processor/values.yaml
@@ -9,6 +9,18 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+# Service Account configuration
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account (for IRSA)
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # Whether to auto mount the service account token
+  automountServiceAccountToken: true
+
 service:
   type: ClusterIP
   port: 3000


### PR DESCRIPTION
- Create serviceaccount.yaml template for IRSA authentication
- Update deployment.yaml with service account and security contexts
- Add values.yaml with service account configuration
- Include values-production.yaml with production-optimized settings
- Configure AWS ALB ingress with proper health checks
- Add HPA configurations for both API and nginx components
- Implement security contexts and resource limits
- Support both IRSA and fallback AWS credential methods
- Add .gitignore entries for Terraform and Helm artifacts